### PR TITLE
Master

### DIFF
--- a/local/handler/paas/ws.go
+++ b/local/handler/paas/ws.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"net/url"
 	"time"
+	"crypto/tls"
+	"strings"
 
 	"github.com/gorilla/websocket"
 	"github.com/yinqiwen/gsnova/local/proxy"
@@ -29,6 +31,13 @@ func (wc *websocketChannel) Open(iv uint64) error {
 	u.Path = "/ws"
 	wsDialer := &websocket.Dialer{}
 	wsDialer.NetDial = paasDial
+
+	if strings.HasSuffix(u.Host, ".herokuapp.com") {
+		wsDialer.TLSClientConfig = &tls.Config{
+			ServerName:         "herokuapp.com",
+			MinVersion:         tls.VersionTLS12,
+		}
+	}
 
 	c, _, err := wsDialer.Dial(u.String(), nil)
 	if err != nil {

--- a/local/proxy/local_server.go
+++ b/local/proxy/local_server.go
@@ -159,7 +159,8 @@ func serveProxyConn(conn net.Conn, proxy ProxyConfig) {
 					sniSniffed = true
 					chunkContent = sniChunk
 					log.Printf("####SNI = %v:%s   %s", sni, socksTargetPort, net.JoinHostPort(sni, socksTargetPort))
-					socksInitProxy(net.JoinHostPort(sni, socksTargetPort))
+		//			socksInitProxy(net.JoinHostPort(sni, socksTargetPort))
+					socksInitProxy(net.JoinHostPort(socksTargetHost, socksTargetPort))
 				}
 			}
 			if nil == p {


### PR DESCRIPTION
ws.go
  通常: client hello ServerName为 url.HOST, 即MyAppName.herokuapp.com
  修改:  强制client hello sni名为 herokuapp.com
  目的:  1) 对中转的sni服务器隐藏了heroku app名   2)实测速度更快，估计sni服务器dns容易解析出主服务器

local_server.go
  测试：tor使用本程序socks5前置时，会出错。而https前置正常。
  修改：不使用sni名走socks5，原因tor这里也是fake sni。仍使用socksTargetHost即可。
  实测：tor前置此socks5通过。建议根据上下文略掉大段sni代码判断。

protected.go
  在windows下编译报错。
  原因：多处 socketFd 类型不对。
  暂时解决：做 int 及 syscall.Handle 强制转换
  建议：多个版本protected.go, 头加入类似// +build !windows

//////////////////////////////////////////////////////////////////////////
目前已部署heroku使用，client.json配置SNIProxy, 测试ok,速度超赞，y2b测速2k-4kbps
请教一：PAAS下ServerList使用一个，不容易卡死。如配置多个ServerList，易卡住。
请教二：请给出样板的client.json，hosts.json及服务端的server.json，及已完成的功能。可配合测试。

看代码猜出的配置如下：
server.json
{
	"Log": ["stdout"],
	"Encrypt":{
		"Method": "salsa20",
		"Key": "12345678901234567890123456789012"
	}
}

hosts.json  //全空
{
}

client.json
{
	// "Log": ["stderr","gsnova.log"],
	"Log": ["stderr"],
	"Encrypt":{
		"Method": "salsa20",
		"Key": "12345678901234567890123456789012"
	},
	"Proxy":[
		{
			"Local": "127.0.0.1:1080",
			"PAC": [
			{
			"Remote": "PAAS"
			}
			]
		},
		{
			"Local": "127.0.0.1:8787",
			"PAC": [
			{
			"Remote": "PAAS"
			}
			]
		}
	],

	"PAAS":{
		"Enable":true,
		"ServerList":[
        //"wss://myapp1.herokuapp.com"
        //"wss://myapp2.herokuapp.com"
        "wss://myapp3.herokuapp.com"
    ],
		"ConnsPerServer": 3,

    //mo
		"SNIProxy": "202.171.253.111"
		//cn
		//"SNIProxy": "120.198.243.86"
    //hk
		//"SNIProxy": "110.4.24.170"
		//"SNIProxy": "219.76.4.14"
		
	}
}
